### PR TITLE
Don't clone repodata for yum

### DIFF
--- a/src/files/utils/yum.ts
+++ b/src/files/utils/yum.ts
@@ -115,11 +115,6 @@ export const addFileToYumRepo = async (store: IFileStore, {
     const storeKey = path.posix.join(app.slug, channel.id, 'linux', 'redhat');
     // Copy the XML files in repodata/
     await fs.mkdir(`${tmpDir}/repodata`);
-    await syncStoreToDirectory(
-      store,
-      `${storeKey}/repodata`,
-      `${tmpDir}/repodata`,
-    );
     // Copy the RPMs
     for (const version of channel.versions) {
       if (!version.dead) {


### PR DESCRIPTION
The repo data for us now has 1,500 files.  The code only copies 1,000 as it is.  The createrepo command can skip a tiny amount of work due to having everything that is in the repodata but cloning it from S3 takes way more time.  It isn't needed for correctness.