### PR TITLE
Only look at files for the correct arch while releasing

### DIFF
--- a/src/rest/app.ts
+++ b/src/rest/app.ts
@@ -304,7 +304,7 @@ router.post('/:id/channel/:channelId/temporary_releases/:temporarySaveId/release
     // Get up to date channel
     const upToDateChannel = (await driver.getChannel(req.targetApp, req.params.channelId))!;
     const storedVersion = upToDateChannel.versions.find(v => v.name === save.version)!;
-    const storedFiles = storedVersion.files.filter(f => storedFileNames.includes(f.fileName));
+    const storedFiles = storedVersion.files.filter(f => storedFileNames.includes(f.fileName) && f.arch === save.arch && f.platform === save.platform);
 
     for (const file of storedFiles) {
       d(`Releasing file: ${file.fileName} to version: ${save.version} for (${req.targetApp.slug}/${channel.name})`);


### PR DESCRIPTION
For Windows file names are the same for the different architectures so the SHAs were being computed incorrectly because it was including files for the wrong architecture.