### PR TITLE
Fix architectures in apt repo

### DIFF
--- a/src/files/utils/apt.ts
+++ b/src/files/utils/apt.ts
@@ -61,7 +61,7 @@ const generateReleaseFile = async (tmpDir: string, app: NucleusApp) => {
 APT::FTPArchive::Release::Label "${app.name}";
 APT::FTPArchive::Release::Suite "stable";
 APT::FTPArchive::Release::Codename "binary";
-APT::FTPArchive::Release::Architectures "i386 amd64";
+APT::FTPArchive::Release::Architectures "amd64 arm64";
 APT::FTPArchive::Release::Components "main";
 APT::FTPArchive::Release::Description "${app.name}";`);
   const [exe, args] = getAptFtpArchiveCommand(tmpDir, ['-c=Release.conf', 'release', '.']);
@@ -76,7 +76,7 @@ APT::FTPArchive::Release::Description "${app.name}";`);
 };
 
 const writeAptMetadata = async (tmpDir: string, app: NucleusApp) => {
-  const packagesContent = await spawnAndGzip(getScanPackagesCommand(tmpDir, ['binary', '/dev/null']), tmpDir);
+  const packagesContent = await spawnAndGzip(getScanPackagesCommand(tmpDir, ['--multiversion', 'binary', '/dev/null']), tmpDir);
   await fs.writeFile(path.resolve(tmpDir, 'binary', 'Packages'), packagesContent[0]);
   await fs.writeFile(path.resolve(tmpDir, 'binary', 'Packages.gz'), packagesContent[1]);
   const sourcesContent = await spawnAndGzip(getScanSourcesCommand(tmpDir, ['binary', '/dev/null']), tmpDir);


### PR DESCRIPTION
#4 turned out to be insufficient

- Replace i386 with arm64 in architecture list
- Pass --multiversion to dpkg-scanpackages to allow multi-architecture packages