### PR TITLE
Mark old versions as dead automatically

### DIFF
--- a/src/db/BaseDriver.ts
+++ b/src/db/BaseDriver.ts
@@ -34,6 +34,8 @@ export abstract class IDBDriver {
   public abstract getMigrations(): Promise<NucleusMigration[]>;
   // SHA
   public abstract storeSHAs(file: NucleusFile, hashes: HashSet): Promise<NucleusFile | null>;
+
+  public abstract markOldVersionsAsDead(channel:NucleusChannel): Promise<void>;
 }
 
 export default abstract class BaseDriver extends IDBDriver {

--- a/src/db/sequelize/SequelizeDriver.ts
+++ b/src/db/sequelize/SequelizeDriver.ts
@@ -453,4 +453,20 @@ export default class SequelizeDriver extends BaseDriver {
 
     return this.fixFileStruct(rawFile);
   }
+
+  public async markOldVersionsAsDead(channel: NucleusChannel) {
+    await this.sequelize!.query(`
+      UPDATE nucleus.Version
+      SET dead = true
+      WHERE channelId = (SELECT id FROM nucleus.Channel c WHERE c.stringId = '${channel.id}') and !dead and id <
+        (SELECT MIN(id)
+         FROM (
+          SELECT v.id
+          FROM nucleus.Version v
+          JOIN nucleus.Channel c ON v.channelId = c.id
+          WHERE c.stringId = '${channel.id}'
+          ORDER BY v.id DESC
+          LIMIT 3) a
+        );`);
+  };
 }

--- a/src/rest/app.ts
+++ b/src/rest/app.ts
@@ -475,6 +475,7 @@ router.post('/:id/channel/:channelId/rollout', requireLogin, noPendingMigrations
       });
     }
     await updateStaticReleaseMetaData(req.targetApp, updatedChannel);
+    await driver.markOldVersionsAsDead(updatedChannel);
     res.json(updatedChannel);
   }
 }));


### PR DESCRIPTION
Nucelus does a lot of downloading from S3 and processing of old versions, and to the best I can tell it doesn't matter at all for any of the platforms, so mark the old ones dead automatically.